### PR TITLE
Support enumeration works for degenerate as well as non-degenerate games

### DIFF
--- a/docs/reference/support-enumeration.rst
+++ b/docs/reference/support-enumeration.rst
@@ -8,7 +8,7 @@ one described in [Nisan2007]_.
 
 The algorithm is as follows:
 
-For a degenerate 2 player game :math:`(A, B)\in{\mathbb{R}^{m\times n}}^2`
+For a degenerate or non-degenerate 2 player game :math:`(A, B)\in{\mathbb{R}^{m\times n}}^2`
 the following algorithm returns all nash equilibria:
 
 1. For all :math:`1\leq k_1\leq m` and :math:`1\leq k_2\leq n`;


### PR DESCRIPTION
As shown in the [README.md](https://github.com/drvinceknight/Nashpy#usage) the support enumeration algorithm does not only work for degenerate but also for non-degenerate games (this is likely only a typo)