### PR TITLE
Update CI tests

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -10,12 +10,12 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -25,8 +25,8 @@ jobs:
 
     - name: install tox
       run: |
-        python -m pip install tox
+        python -m pip install tox tox-gh-actions
 
     - name: run tox
       run: |
-        python -m tox -e py38  # TODO When able to use py39 on github actions modify.
+        python -m tox

--- a/docs/contributing/reference/contributors/index.rst
+++ b/docs/contributing/reference/contributors/index.rst
@@ -3,3 +3,4 @@ List of contributors
 
 - `@drvinceknight <https://github.com/drvinceknight>`_
 - `@11michalis11 <https://github.com/11michalis11>`_
+- `@asinghgaba <https://github.com/asinghgaba>`_

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 isolated_build = True
 envlist = py38, py39
 
+[gh-actions]
+python =
+    3.8: py38
+    3.9: py39
+
 [testenv]
 deps =
     black


### PR DESCRIPTION
Fixes #119 

Now added support for Python 3.9 and uses tox-gh-actions.
Also changed the version for checkout and setup-python.