### PR TITLE
Complexity improvement for fictitious play

### DIFF
--- a/src/nashpy/learning/stochastic_fictitious_play.py
+++ b/src/nashpy/learning/stochastic_fictitious_play.py
@@ -1,7 +1,27 @@
 """Code to carry out stochastic fictitious learning"""
 import numpy as np
-from nashpy.learning.fictitious_play import update_play_count
 import numpy.typing as npt
+
+
+def update_play_count(play_count: npt.NDArray, play: int) -> npt.NDArray:
+    """
+    Update a belief vector with a given play
+
+    Parameters
+    ----------
+    play_count : array
+        The play counts.
+    play : int
+        The given play.
+
+    Returns
+    -------
+    array
+        The updated play counts.
+    """
+    extra_play = np.zeros(play_count.shape)
+    extra_play[play] = 1
+    return play_count + extra_play
 
 
 def get_distribution_response_to_play_count(

--- a/tests/unit/test_fictitious_play.py
+++ b/tests/unit/test_fictitious_play.py
@@ -10,39 +10,7 @@ from hypothesis.strategies import integers
 
 from nashpy.learning.fictitious_play import (
     fictitious_play,
-    get_best_response_to_play_count,
-    update_play_count,
 )
-
-
-@given(M=arrays(np.int8, (4, 5)))
-def test_property_find_best_response_to_play_count(M):
-    play_count = np.zeros(M.shape[1])
-    best_response = get_best_response_to_play_count(M, play_count)
-    assert best_response >= 0
-    assert best_response <= M.shape[1] - 1
-
-
-def test_find_best_response_to_play_count():
-    M = np.array([[3, 2, 3], [4, 1, 1], [2, 3, 1]])
-    play_counts = (
-        np.array([1, 0, 0]),
-        np.array([2, 1, 0]),
-        np.array([0, 0, 2]),
-    )
-    best_responses = (1, 1, 0)
-    for play_count, expected_best_response in zip(play_counts, best_responses):
-        best_response = get_best_response_to_play_count(M, play_count)
-        assert best_response == expected_best_response, play_count
-
-
-@given(play=integers(min_value=0, max_value=9))
-def test_property_update_belief(play):
-    play_count = np.zeros(10)
-    updated_play_count = update_play_count(play_count, play)
-    assert play_count[play] + 1 == updated_play_count[play]
-    assert np.array_equal(play_count[:play], updated_play_count[:play])
-    assert np.array_equal(play_count[play + 1 :], updated_play_count[play + 1 :])
 
 
 @given(


### PR DESCRIPTION
 close #202

passes the tests

```py
from time import time
import numpy as np

from nashpy.learning.fictitious_play import fictitious_play, fictitious_play2

shape = (2000, 2000)
n_iter = 100
A = np.random.rand(*shape)
B = np.random.rand(*shape)

d = time()
gen = fictitious_play(A, B, n_iter)
for play_count in gen:
    pass
print(time() - d, "s")

d = time()
gen = fictitious_play2(A, B, n_iter)
for play_count in gen:
    pass
print(time() - d, "s")
```

```
0.23587727546691895 s
0.005759000778198242 s
```