### PR TITLE
Added a degenerate game that breaks lemke howson lex algorithm

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/tests/unit/test_lemke_howson_lex.py
+++ b/tests/unit/test_lemke_howson_lex.py
@@ -56,3 +56,36 @@ class TestLemkeHowsonLex(unittest.TestCase):
                 (np.array([0, 1, 0]), np.array([1, 0, 0])),
             ):
                 self.assertTrue(all(np.isclose(eq, expected_eq)))
+
+    @unittest.skip("game currently not stable")
+    def test_lemke_howson_lex_degenerate_tie_breaking_looping(
+        self,
+    ):
+        A = np.array(
+            [
+                [0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [0.711, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [1.0, 0.672, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0, 1.0],
+                [1.0, 1.0, 0.667, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0],
+                [1.0, 1.0, 1.0, 0.579, 0.0, 0.0, 0.5, 1.0, 1.0],
+                [1.0, 1.0, 1.0, 1.0, 0.5, 0.0, 0.0, 0.5, 1.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.0, 0.0, 1.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.333, 0.0, 0.5],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0],
+            ]
+        )
+        B = 1 - A
+        expected_reward = 0.75872890672  # from support vector calc
+        # label 1 works, 0 crashes, and 2 loops infinitely
+        for label in [1, 0, 2]:
+            found_eq = False
+            with self.subTest(label=label):
+                eq = lemke_howson_lex(A, B, label)
+                self.assertFalse(
+                    np.isnan(eq[0]).any() or np.isnan(eq[1]).any(),
+                    "strategy is not nan",
+                )
+                reward = eq[0].dot(A).dot(eq[1].transpose())
+                self.assertAlmostEqual(reward, expected_reward, delta=1e-7)
+                found_eq = True
+            self.assertTrue(found_eq, "Did not find eq on label " + str(label))

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     interrogate
     matplotlib
     mypy
-    pytest
+    pytest-subtests
     pytest-cov
     pytest-randomly
     pytest-sugar


### PR DESCRIPTION
This pr contains a game that doesn't solve with either standard or lexicographic lemke howson algorithm. My novice attempts at correcting the underlying issue has failed, but I believe its due to a bug in the tie breaking rules.

Section 3 in both http://ints.io/daveagp/gta/lecture6.pdf and http://www.maths.lse.ac.uk/personal/stengel/TEXTE/geb1996b.pdf seems to suggest that lexiographic sorting should be used together with a small error vector to break ties, but I'm not sure how exactly that would be applied to https://github.com/drvinceknight/Nashpy/blob/main/src/nashpy/integer_pivoting/integer_pivoting_lex.py#L12