### PR TITLE
edit home-page element

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
     "networkx >= 3.0.0",
     "deprecated >= 1.2.14"
 ]
-home-page = "https://vknight.org"
+home-page = "https://github.com/drvinceknight/Nashpy"
 requires-python= ">=3.8"
 description-file = "README.md"
 classifiers = [ "License :: OSI Approved :: MIT License",]


### PR DESCRIPTION
I recommend minor edit of metadata in pyproject file. The current home-page element refers to the author of this project, while it would be more convenient to refer to the project repository. The intention of the home-page is also described in https://flit.pypa.io/en/latest/pyproject_toml.html, which states that the home-page element is "A URL for the project, such as its GitHub repository." It also comes to the effect here: https://pypi.org/project/nashpy/, where referring to the project repository is not straightforward.

